### PR TITLE
Add buildToolsVersion ARG to Android Dockerfile

### DIFF
--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -76,9 +76,8 @@ RUN mv android-sdk-linux $ANDROID_HOME
 RUN rm android-sdk_r${androidSdkVersion}-linux.tgz
 
 # Install Android tools
-RUN if ! [[ -z "${androidComponents}"]]; then toBeInstalled=${androidComponents},; fi
-RUN toBeInstalled=${toBeInstalled}build-tools-${buildToolsVersion}
-RUN echo y | ${ANDROID_HOME}/tools/android update sdk --filter "${toBeInstalled}" --no-ui -a
+# Installe the buildToolsVersion specified as an extra
+RUN if ! [ -z "${androidComponents}" ]; then echo y | ${ANDROID_HOME}/tools/android update sdk --filter "${androidComponents},build-tools-${buildToolsVersion}" --no-ui -a; else echo y | ${ANDROID_HOME}/tools/android update sdk --filter "build-tools-${buildToolsVersion}" --no-ui -a; fi
 
 # Environment variables
 ENV ANDROID_SDK_HOME $ANDROID_HOME

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -6,6 +6,7 @@ ARG gradleVersion=2.2
 ARG androidComponents=platform-tools,extra-android-support,extra-android-m2repository,extra-google-m2repository
 ARG javaPackage=openjdk-8-jdk
 ARG androidSdkVersion=24.4.1
+ARG buildToolsVersion=21.1.2
 
 MAINTAINER Jason Rogena "jasonrogena@gmail.com"
 
@@ -75,13 +76,15 @@ RUN mv android-sdk-linux $ANDROID_HOME
 RUN rm android-sdk_r${androidSdkVersion}-linux.tgz
 
 # Install Android tools
-RUN echo y | ${ANDROID_HOME}/tools/android update sdk --filter "${androidComponents}" --no-ui -a
+RUN if ! [[ -z "${androidComponents}"]]; then toBeInstalled=${androidComponents},; fi
+RUN toBeInstalled=${toBeInstalled}build-tools-${buildToolsVersion}
+RUN echo y | ${ANDROID_HOME}/tools/android update sdk --filter "${toBeInstalled}" --no-ui -a
 
 # Environment variables
 ENV ANDROID_SDK_HOME $ANDROID_HOME
 ENV PATH $PATH:$ANDROID_SDK_HOME/tools
 ENV PATH $PATH:$ANDROID_SDK_HOME/platform-tools
-ENV PATH $PATH:$ANDROID_SDK_HOME/build-tools/21.1.2
+ENV PATH $PATH:$ANDROID_SDK_HOME/build-tools/${buildToolsVersion}
 
 # Install Gradle
 WORKDIR /usr/bin

--- a/android/README.md
+++ b/android/README.md
@@ -6,6 +6,7 @@ This Dockerfile has configurable args:
   - androidComponents (defaults to platform-tools,extra-android-support,extra-android-m2repository,extra-google-m2repository)
   - javaPackage (defaults to openjdk-8-jdk)
   - androidSdkVersion (defaults to 24.4.1)
+  - buildToolsVersion (defaults to 21.1.2)
 
 ## Running the Dockerfile
 

--- a/android/README.md
+++ b/android/README.md
@@ -12,5 +12,5 @@ This Dockerfile has configurable args:
 
 Run the following commands to create a Docker image from the Dockerfile and then a container from the image:
 
-    docker build -t onaio/android:java8 --build-arg "androidComponents=platform-tools,android-21,build-tools-21.1.2,extra-android-support,extra-android-m2repository,extra-google-m2repository" .
+    docker build -t onaio/android:java8 --build-arg "androidComponents=platform-tools,android-21,extra-android-support,extra-android-m2repository,extra-google-m2repository" .
     docker run -i -t onaio/android:java8


### PR DESCRIPTION
Add the buildToolsVersion ARG to the Android Dockerfile

Fix for issue #7

Signed-off-by: Jason Rogena jasonrogena@gmail.com
