### PR TITLE
Add redis on standard port to clojure dockerfile

### DIFF
--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -2,6 +2,10 @@ FROM clojure
 
 MAINTAINER Roy Rutto <rrutto@ona.io>
 
+RUN         apt-get update && apt-get install -y redis-server
+EXPOSE      6379
+ENTRYPOINT  ["/usr/bin/redis-server"]
+
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
   && apt-get install -y nodejs Xvfb bzip2 \
   &&  npm install -g phantomjs \


### PR DESCRIPTION
This is needed for zebra tests on the csv upload branch and future to pass (this relies on making connections to redis from the app)